### PR TITLE
Add Travis CI config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Go binary
-yaml2json
+# Go binaries
+/yaml2json
+/json2yaml
 
 # Compiled Python bytecode
 *.pyc

--- a/.travis.jsonnet
+++ b/.travis.jsonnet
@@ -1,0 +1,63 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local goVersions = ["1.11.x", "1.12.x", "1.13.x"];
+
+# Correspondence between XCode versions and Python versions on macOS found in this blog post:
+# https://blog.travis-ci.com/2019-08-07-extensive-python-testing-on-travis-ci
+local pyVersions = {
+    "2.7": "xcode_9.3",
+    "3.6": "xcode_9.4",
+    "3.7": "xcode_10.2",
+};
+local oses = ["linux", "osx"];
+
+local goSpec = function(goVer, os) {
+  language: "go",
+  go: goVer,
+  os: os,
+  env: ["GO111MODULE=on", "VERBOSE=1"],
+  before_script: ["make go-build"],
+  script: ["make go-test"],
+};
+
+local pySpec = function(pyVer, os) {
+  language: if os == "linux" then "python" else "generic",
+  python: if os == "linux" then pyVer,
+  osx_image: if os == "osx" then pyVersions[pyVer],
+  os: os,
+  env: ["VERBOSE=1"],
+  before_script: ["make py-install"],
+  script: ["make py-test"],
+};
+
+# Output the parameterized config.
+{
+  dist: "bionic",
+  # Travis CI warns about lack of a top-level "language" field, and assumes
+  # "ruby".
+  language: "generic",
+  branches: {
+    only: ["master"],
+  },
+  jobs: {
+    include:
+        [goSpec(goVer, os) for goVer in goVersions for os in oses] +
+        [pySpec(pyVer, os) for pyVer in std.objectFields(pyVersions) for os in oses],
+    allow_failures: {
+      os: "osx"
+    },
+    fast_finish: true,
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,145 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+branches:
+  only:
+  - master
+dist: bionic
+jobs:
+  allow_failures:
+    os: osx
+  fast_finish: true
+  include:
+  - before_script:
+    - make go-build
+    env:
+    - GO111MODULE=on
+    - VERBOSE=1
+    go: 1.11.x
+    language: go
+    os: linux
+    script:
+    - make go-test
+  - before_script:
+    - make go-build
+    env:
+    - GO111MODULE=on
+    - VERBOSE=1
+    go: 1.11.x
+    language: go
+    os: osx
+    script:
+    - make go-test
+  - before_script:
+    - make go-build
+    env:
+    - GO111MODULE=on
+    - VERBOSE=1
+    go: 1.12.x
+    language: go
+    os: linux
+    script:
+    - make go-test
+  - before_script:
+    - make go-build
+    env:
+    - GO111MODULE=on
+    - VERBOSE=1
+    go: 1.12.x
+    language: go
+    os: osx
+    script:
+    - make go-test
+  - before_script:
+    - make go-build
+    env:
+    - GO111MODULE=on
+    - VERBOSE=1
+    go: 1.13.x
+    language: go
+    os: linux
+    script:
+    - make go-test
+  - before_script:
+    - make go-build
+    env:
+    - GO111MODULE=on
+    - VERBOSE=1
+    go: 1.13.x
+    language: go
+    os: osx
+    script:
+    - make go-test
+  - before_script:
+    - make py-install
+    env:
+    - VERBOSE=1
+    language: python
+    os: linux
+    osx_image: null
+    python: "2.7"
+    script:
+    - make py-test
+  - before_script:
+    - make py-install
+    env:
+    - VERBOSE=1
+    language: generic
+    os: osx
+    osx_image: xcode_9.3
+    python: null
+    script:
+    - make py-test
+  - before_script:
+    - make py-install
+    env:
+    - VERBOSE=1
+    language: python
+    os: linux
+    osx_image: null
+    python: "3.6"
+    script:
+    - make py-test
+  - before_script:
+    - make py-install
+    env:
+    - VERBOSE=1
+    language: generic
+    os: osx
+    osx_image: xcode_9.4
+    python: null
+    script:
+    - make py-test
+  - before_script:
+    - make py-install
+    env:
+    - VERBOSE=1
+    language: python
+    os: linux
+    osx_image: null
+    python: "3.7"
+    script:
+    - make py-test
+  - before_script:
+    - make py-install
+    env:
+    - VERBOSE=1
+    language: generic
+    os: osx
+    osx_image: xcode_10.2
+    python: null
+    script:
+    - make py-test
+language: generic
+

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ go-build: yaml2json
 # include here.
 yaml2json: yaml2json.go
 	$(VERB) echo "Building Go binary ..."
-	$(VERB) go build ./...
+	$(VERB) go build .
 
 clean:
 	$(VERB) rm -rf "$(THIRD_PARTY_PYTHON)"/*
@@ -66,3 +66,12 @@ test: go-test py-test
 
 regen: build
 	$(VERB) ./regen.sh
+
+travis: .travis.yml
+
+json2yaml: cmd/json2yaml/json2yaml.go
+	$(VERB) go build ./cmd/json2yaml
+
+.travis.yml: .travis.jsonnet json2yaml
+	$(VERB) jsonnet "$<" | ./json2yaml > "$@"
+	$(VERB) autogen --no-tlc -c "Google LLC" -i "$@"

--- a/cmd/json2yaml/json2yaml.go
+++ b/cmd/json2yaml/json2yaml.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ghodss/yaml"
+)
+
+const (
+	prettyPrint = true
+	indent      = 2
+)
+
+type JsonToYamlOptions struct {
+	PrettyPrint bool
+	Indent      int
+}
+
+func JsonToYaml(jsonData []byte, options JsonToYamlOptions) string {
+	var o interface{}
+	jsonErr := json.Unmarshal(jsonData, &o)
+	if jsonErr != nil {
+		fmt.Fprintf(os.Stderr, "JSON parsing error: %v\n", jsonErr)
+		os.Exit(1)
+	}
+
+	var yamlData []byte
+	var yamlErr error
+	yamlData, yamlErr = yaml.Marshal(o)
+	if yamlErr != nil {
+		fmt.Fprintf(os.Stderr, "JSON marshal error: %v\n", yamlErr)
+		os.Exit(2)
+	}
+	return string(yamlData)
+}
+
+func main() {
+	var jsonData []byte
+	var readErr error
+	if len(os.Args) < 2 {
+		jsonData, readErr = ioutil.ReadAll(os.Stdin)
+	} else {
+		jsonData, readErr = ioutil.ReadFile(os.Args[1])
+	}
+	if readErr != nil {
+		fmt.Fprintf(os.Stderr, "Error reading JSON input: %v\n", readErr)
+		os.Exit(1)
+	}
+	options := JsonToYamlOptions{
+		PrettyPrint: true,
+		Indent:      2,
+	}
+	fmt.Println(JsonToYaml(jsonData, options))
+}


### PR DESCRIPTION
Since we have a number of Go versions, Python versions, and OSes, we are
using Jsonnet to generate the cross-product of these possible
configurations, and then converting the config for Travis CI's
consumption as follows:

1. Jsonnet -> JSON (via `jsonnet`)
2. JSON -> YAML (via custom `json2yaml` tool in this repo, which is
   added as part of this PR. Note that since JSON is a subset of YAML,
   this step is not strictly required, but the output is more readable
   this way)
3. adding a license comment at the top of the file via `autogen`