### PR TITLE
Separate Python vs. Go tests for easier testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 VERB = @
 ifeq ($(VERBOSE),1)
-	VER =
+	VERB =
 endif
 
 THIRD_PARTY_PYTHON = third_party/python
@@ -25,7 +25,7 @@ THIRD_PARTY_PYTHON = third_party/python
 py-install:
 	$(VERB) pip install -r requirements.txt -t "$(THIRD_PARTY_PYTHON)"
 
-build: yaml2json
+go-build: yaml2json
 
 # For now, our binary only includes a single Go file; if this were to change, we
 # would need to dynamically discover the full set of local dependencies to
@@ -38,9 +38,14 @@ clean:
 	$(VERB) rm -rf "$(THIRD_PARTY_PYTHON)"/*
 	$(VERB) rm -f yaml2json
 
-yaml_to_json_tests:
-	$(VERB) echo "YAML -> JSON tests"
-	$(VERB) ./run_tests.sh
+go_yaml_to_json_test:
+	$(VERB) echo "Go YAML -> JSON tests"
+	$(VERB) ./go_yaml_to_json_test.sh
+	$(VERB) echo
+
+py_yaml_to_json_test:
+	$(VERB) echo "Python YAML -> JSON tests"
+	$(VERB) ./py_yaml_to_json_test.sh
 	$(VERB) echo
 
 gofmt_test:
@@ -53,7 +58,11 @@ go_mod_tidy_test:
 	$(VERB) ./go_mod_tidy_test.sh
 	$(VERB) echo
 
-test: build yaml_to_json_tests gofmt_test go_mod_tidy_test
+go-test: go-build go_yaml_to_json_test gofmt_test go_mod_tidy_test
+
+py-test: py_yaml_to_json_test
+
+test: go-test py-test
 
 regen: build
 	$(VERB) ./regen.sh

--- a/go_yaml_to_json_test.sh
+++ b/go_yaml_to_json_test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -u
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs all the YAML -> JSON tests in Go.
+
+declare -i go_passed=0
+declare -i go_total=0
+
+for yaml in testdata/*.yaml; do
+  json="${yaml/%.yaml}.json"
+
+  echo "Testing: ${yaml} in Go ..."
+  diff -u <(./yaml2json < "${yaml}") "${json}"
+  if [ $? -eq 0 ];  then
+    (( go_passed += 1 ))
+  else
+    echo
+  fi
+  (( go_total += 1 ))
+done
+
+echo "Go:     ${go_passed} / ${go_total} passed"
+
+if [ ${go_passed} -ne ${go_total} ]; then
+  exit 1
+fi

--- a/py_yaml_to_json_test.sh
+++ b/py_yaml_to_json_test.sh
@@ -14,13 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Runs all the YAML -> JSON tests in both Python and Go.
+# Runs all the YAML -> JSON tests in Python.
 
 declare -i py_passed=0
 declare -i py_total=0
-
-declare -i go_passed=0
-declare -i go_total=0
 
 for yaml in testdata/*.yaml; do
   json="${yaml/%.yaml}.json"
@@ -33,20 +30,10 @@ for yaml in testdata/*.yaml; do
     echo
   fi
   (( py_total += 1 ))
-
-  echo "Testing: ${yaml} in Go ..."
-  diff -u <(./yaml2json < "${yaml}") "${json}"
-  if [ $? -eq 0 ];  then
-    (( go_passed += 1 ))
-  else
-    echo
-  fi
-  (( go_total += 1 ))
 done
 
 echo "Python: ${py_passed} / ${py_total} passed"
-echo "Go:     ${go_passed} / ${go_total} passed"
 
-if [ ${py_passed} -ne ${py_total} ] || [ ${go_passed} -ne ${go_total} ]; then
-	exit 1
+if [ ${py_passed} -ne ${py_total} ]; then
+  exit 1
 fi


### PR DESCRIPTION
This is necessary to be able to run them on various version of Python
and Go runtimes, when we can only install one of the specific language
versions or runtimes at a time.

Now, `make py-test` will just run the Python tests while `make go-test`
will run just the Go tests, and `make test` will continue to run the
combined set of tests for simple development workflow.