### PR TITLE
Fix `make regen` dependency on `go-build` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,5 @@ py-test: py_yaml_to_json_test
 
 test: go-test py-test
 
-regen: build
+regen: go-build
 	$(VERB) ./regen.sh


### PR DESCRIPTION
Updated the no longer existing `make build` target to `make go-build` so
that `make regen` works again.