### PR TITLE
Convert `pip install` to `python -m pip install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ THIRD_PARTY_PYTHON = third_party/python
 	$(VERB) echo "Available targets: py-install, clean, build, test, regen"
 
 py-install:
-	$(VERB) pip install -r requirements.txt -t "$(THIRD_PARTY_PYTHON)"
+	$(VERB) python -m pip install -r requirements.txt -t "$(THIRD_PARTY_PYTHON)"
 
 go-build: yaml2json json2yaml
 


### PR DESCRIPTION
This is the new recommended installation command as it's clearer which Python version is being used to install the new package:

* https://pip.pypa.io/en/stable/getting-started/
* https://bugs.python.org/issue22295
* https://stackoverflow.com/a/25749976/3618671