### PR TITLE
Move from `go get` to `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ written separately in Python and Go.
 
 # Usage
 
-Build the Go utilities:
+Install the Go utilities:
 
 ```shell
-$ go get -u github.com/mbrukman/yaml2json/cmd/{yaml2json,json2yaml}
+$ go install github.com/mbrukman/yaml2json/cmd/{yaml2json,json2yaml}@latest
 ```
 
 Convert YAML &rarr; JSON:


### PR DESCRIPTION
`go install` is the future-compatible way of installing Go binaries; `go get` will change in the future to only download and build libraries but will not be installing binaries, so let's migrate now to avoid user confusion later.

Since we're not modifying code, we can [skip ci].