### PR TITLE
Add separate file path matchers for Python and Go

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,11 +14,48 @@
 
 name: "Go"
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ main ]
+    paths:
+        # Go source files
+      - '**/*.go'
+        # Go config files
+      - 'go.mod'
+      - 'go.sum'
+        # Go-relevant shell scripts
+      - 'go*.sh'
+      - 'regen.sh'
+        # Cross-language build files and scripts
+      - 'Makefile'
+      - 'json_to_yaml_test.sh'
+        # Test data
+      - 'testdata/**'
+        # Go CI configs
+      - '.github/workflows/go.yaml' # this file
+
   pull_request:
     branches: [ main ]
+    paths:
+        # Go source files
+      - '**/*.go'
+        # Go config files
+      - 'go.mod'
+      - 'go.sum'
+        # Go-relevant shell scripts
+      - 'go*.sh'
+      - 'regen.sh'
+        # Cross-language build files and scripts
+      - 'Makefile'
+      - 'json_to_yaml_test.sh'
+        # Test data
+      - 'testdata/**'
+        # Go CI configs
+      - '.github/workflows/go.yaml' # this file
+
   schedule:
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
       #

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -14,11 +14,39 @@
 
 name: "Python"
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ main ]
+    paths:
+        # Python source files
+      - '**/*.py'
+        # Python config files
+      - 'requirements.txt'
+        # Cross-language build files and scripts
+      - 'Makefile'
+      - 'json_to_yaml_test.sh'
+        # Test data
+      - 'testdata/**'
+        # Python CI configs
+      - '.github/workflows/python.yaml' # this file
+
   pull_request:
     branches: [ main ]
+        # Python source files
+      - '**/*.py'
+        # Python config files
+      - 'requirements.txt'
+        # Cross-language build files and scripts
+      - 'Makefile'
+      - 'json_to_yaml_test.sh'
+        # Test data
+      - 'testdata/**'
+        # Python CI configs
+      - '.github/workflows/python.yaml' # this file
+
   schedule:
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
       #


### PR DESCRIPTION
This will enable us to run fewer builds when we only modify files relevant to one build or the other, as well as exclude builds entirely when modifying README.md or other documentation not relevant to the code or tests entirely.