### PR TITLE
Rename GitHub Actions badge and URL anchor names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # yaml2json
 
-[![Python build status][github-python-ci-badge]][github-python-ci-url]
-[![Go build status][github-go-ci-badge]][github-go-ci-url]
+[![Python build status][yaml2json-python-ci-badge]][yaml2json-python-ci-url]
+[![Go build status][yaml2json-go-ci-badge]][yaml2json-go-ci-url]
 [![Go Report Card][go-report-card-badge]][go-report-card-url]
 
-[github-python-ci-badge]: https://github.com/mbrukman/yaml2json/actions/workflows/python.yaml/badge.svg?query=branch%3Amain
-[github-python-ci-url]: https://github.com/mbrukman/yaml2json/actions/workflows/python.yaml?query=branch%3Amain
-[github-go-ci-badge]: https://github.com/mbrukman/yaml2json/actions/workflows/go.yaml/badge.svg?query=branch%3Amain
-[github-go-ci-url]: https://github.com/mbrukman/yaml2json/actions/workflows/go.yaml?query=branch%3Amain
+[yaml2json-python-ci-badge]: https://github.com/mbrukman/yaml2json/actions/workflows/python.yaml/badge.svg?query=branch%3Amain
+[yaml2json-python-ci-url]: https://github.com/mbrukman/yaml2json/actions/workflows/python.yaml?query=branch%3Amain
+[yaml2json-go-ci-badge]: https://github.com/mbrukman/yaml2json/actions/workflows/go.yaml/badge.svg?query=branch%3Amain
+[yaml2json-go-ci-url]: https://github.com/mbrukman/yaml2json/actions/workflows/go.yaml?query=branch%3Amain
 [go-report-card-badge]: https://goreportcard.com/badge/github.com/mbrukman/yaml2json
 [go-report-card-url]: https://goreportcard.com/report/github.com/mbrukman/yaml2json
 


### PR DESCRIPTION
This makes it easier to copy-paste into my multi-project status page.